### PR TITLE
Added RosePolly link and 2013 LCPC publication entry (clean)

### DIFF
--- a/Publications.bib
+++ b/Publications.bib
@@ -502,6 +502,32 @@ evaluation using PolyBench.
   year = 2013
 }
 
+@inproceedings{Konstantinidis2013parametric,
+  title={Parametric GPU code generation for affine loop programs},
+  author={Konstantinidis, Athanasios and Kelly, Paul HJ and Ramanujam, J and Sadayappan, P},
+  booktitle={International Workshop on Languages and Compilers for Parallel Computing},
+  pages={136--151},
+  year={2013},
+  organization={Springer},
+  url={https://parasol.tamu.edu/lcpc2013/papers/lcpc2013_submission_21.pdf},
+  abstract={
+  Partitioning a parallel computation into finitely sized chunks for effective
+  mapping onto a parallel machine is a critical concern for source-to-source
+  compilation. In the context of OpenCL and CUDA, this translates to the definition
+  of a uniform hyper-rectangular partitioning of the parallel execution space
+  where each partition is subject to a fine-grained distribution of resources that has
+  a direct yet hard to estimate impact on performance. This paper develops the first
+  compilation scheme for generating parametrically tiled codes for affine loop programs
+  on GPUs which facilitates run-time exploration of partitioning parameters
+  as a fast and portable way of finding the ones that yield maximum performance.
+  Our approach is based on a parametric tiling scheme for producing wavefronts
+  of parallel rectangular partitions of parametric size and a novel runtime system
+  that manages wavefront execution and local memory usage dynamically through
+  an inspector-executor mechanism. Our experimental evaluation demonstrates the
+  effectiveness of our approach for wavefront as well as rectangularly-parallel partitionings.
+  }
+}
+
 @inproceedings{Kong2013polyhedral,
  title={When polyhedral transformations meet SIMD code generation},
  author={Kong, Martin and Veras, Richard and Stock, Kevin and Franchetti, Franz and Pouchet, Louis-No{\"e}l and Sadayappan, P},

--- a/software.md
+++ b/software.md
@@ -39,6 +39,7 @@ Compilers
  * [PoCC](http://www.cse.ohio-state.edu/~pouchet/software/pocc/pocc.html)
  * [PolyOpt/C](http://hpcrl.cse.ohio-state.edu/wiki/index.php/PolyOpt/C) <a class="citation">POUCHET2011POLYOPT</a>
  * [PolyOpt/Fortran](http://hpcrl.cse.ohio-state.edu/wiki/index.php/PolyOpt/Fortran)
+ * [RosePolly](https://github.com/rose-compiler/rose/tree/master/projects/RosePolly)
  * [PPCG](http://ppcg.gforge.inria.fr/), <a class="citation">VERDOOLAEGE2013PPCG</a>
  * [R-Stream](https://www.reservoir.com/products), <a class="citation">SCHWEITZ2006RSTREAM</a>
 


### PR DESCRIPTION
I have placed the RosePolly github link in the "source-to-source" list of the "software" section.
I placed it right after the PolyOpt links because it is based on ROSE as well.