### PR TITLE
Fix broken link for PolyLib publication

### DIFF
--- a/Publications.bib
+++ b/Publications.bib
@@ -2478,7 +2478,7 @@ the polytope model and to enable the generation of competitive target code."
  title={PolyLib: A library for manipulating parameterized polyhedra},
  author={Loechner, Vincent},
  year={1999},
- url={http://camlunity.ru/swap/Library/Conflux/Techniques%20-%20Code%20Analysis%20and%20Transformations%20(Polyhedral)/Free%20Libraries/polylib.ps}
+ url={https://repo.or.cz/polylib.git/blob_plain/HEAD:/doc/parampoly-doc.ps.gz}
 }
 
 @article{Kelly1995petit,


### PR DESCRIPTION
Previous link was 404. This link is to the authors repository I found via http://icps.u-strasbg.fr/PolyLib/